### PR TITLE
Add vega and polaris

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -49,6 +49,15 @@ jobs:
       run: |-
         python clean_full.py ${{env.version}} > configs/link_full.txt
         echo "link_full=$(cat configs/link_full.txt)" >> $GITHUB_ENV
+    - name: Clear link_full_combined.txt
+      run: echo "" > configs/link_full_combined.txt
+    - name: Fetch link for full setup combined(Polaris/Vega + RDNA)
+      if: env.link != env.old_link && env.tag != env.latest_tag
+      run: |-
+        python clean_full_combined.py ${{env.version}} > configs/link_full_combined.txt
+        if [ -s configs/link_full_combined.txt ]; then
+          echo "link_full_combined=$(cat configs/link_full_combined.txt)" >> $GITHUB_ENV
+        fi
     - name: Save new minimal setup
       if: env.link != env.old_link && env.tag != env.latest_tag
       run:  |-
@@ -57,6 +66,10 @@ jobs:
       if: env.link != env.old_link && env.tag != env.latest_tag
       run:  |-
         curl --create-dirs -O --output-dir "driver" '${{ env.link_full }}' -K configs/headers.txt --compressed
+    - name: Save new full setup combined (Polaris/Vega + RDNA)
+      if: env.link != env.old_link && env.tag != env.latest_tag && env.link_full_combined
+      run: |-
+        curl --create-dirs -O --output-dir "driver" '${{ env.link_full_combined }}' -K configs/headers.txt --compressed
     - name: Generate new changelog
       if: env.link != env.old_link && env.tag != env.latest_tag
       run: |-

--- a/clean_full_combined.py
+++ b/clean_full_combined.py
@@ -1,0 +1,12 @@
+import sys
+import requests
+from bs4 import BeautifulSoup
+
+headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36', "Upgrade-Insecure-Requests": "1","DNT": "1","Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8","Accept-Language": "en-US,en;q=0.5","Accept-Encoding": "gzip, deflate"}
+html = requests.get(f'https://www.amd.com/en/resources/support-articles/release-notes/RN-RAD-WIN-{sys.argv[1]}.html',headers=headers).content
+
+soup = BeautifulSoup(html, 'html.parser')
+a = soup.select('a[href*="/drivers/"]')
+link = a[1].get('href')
+
+print(link)


### PR DESCRIPTION
- Added `clean_full_combined.py` script to fetch the link for the full setup combined (Polaris/Vega + RDNA) and output it to `configs/link_full_combined.txt`.
- Added a step to clear the contents of `configs/link_full_combined.txt` on workflow to ensure it starts empty for each run.
- Modified the step to set `link_full_combined` only if `configs/link_full_combined.txt` is not empty.
- Updated conditional checks to ensure steps related to "full setup combined" only run if a new link is generated.
