### PR TITLE
Driver optional - new feature

### DIFF
--- a/.github/workflows/optional-scrape.yml
+++ b/.github/workflows/optional-scrape.yml
@@ -67,7 +67,7 @@ jobs:
         gh release create ${{ env.beta_tag }} \
           -t "${{ env.beta_tag }}" \
           -F configs/generated_changelog_optional.md \
-          --prerelease --draft
+          --prerelease
           
         gh release upload ${{ env.beta_tag }} ./driver/*.exe
 

--- a/.github/workflows/optional-scrape.yml
+++ b/.github/workflows/optional-scrape.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
-  push: 
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT_AMD }}

--- a/.github/workflows/optional-scrape.yml
+++ b/.github/workflows/optional-scrape.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
+  push: 
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT_AMD }}

--- a/.github/workflows/optional-scrape.yml
+++ b/.github/workflows/optional-scrape.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Create new Beta Release
       run: |-
         gh release create ${{ env.beta_tag }} \
-          -t "${{ env.beta_tag }} Beta (TEST)" \
+          -t "${{ env.beta_tag }}" \
           -F configs/generated_changelog_optional.md \
           --prerelease --draft
           

--- a/.github/workflows/optional-scrape.yml
+++ b/.github/workflows/optional-scrape.yml
@@ -1,0 +1,83 @@
+name: Scrape optional data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PAT_AMD }}
+
+jobs:
+  scheduled:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out this repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.PAT_AMD }}
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install deps
+      run: >-
+          python -m pip install --upgrade pip &&
+          pip install beautifulsoup4 && pip install requests && pip install markdownify
+
+    - name: Check for AMD optional new versions
+      run: |-
+        echo "old_link_optional=$(cat configs/link_optional.txt 2>/dev/null || echo '')" >> $GITHUB_ENV
+        python clean_optional.py > configs/link_optional.txt
+        echo "link_optional=$(cat configs/link_optional.txt)" >> $GITHUB_ENV        
+
+    - name: Create Version
+      if: env.link_optional != env.old_link_optional
+      run: |-
+        version=$(echo "${{ env.link_optional }}" | grep -oP '(version=)|(\d\d\.\d\d?\.\d\d?)' | tr -d "\n" | tr  "."  "-")
+        echo "version=$version" >> $GITHUB_ENV   
+
+    - name: Create beta tag
+      if: env.link_optional != env.old_link_optional
+      run: |-
+        beta_tag="${{ env.version }}-beta"
+        echo "beta_tag=$beta_tag" >> $GITHUB_ENV
+
+    - name: Check if Beta Release already exists
+      if: env.link_optional != env.old_link_optional
+      run: |-
+        if gh release list --json tagName --jq '.[] | select(.tagName=="${{ env.beta_tag }}")' | grep -q .; then
+          echo "Beta release já existe. Saindo..."
+          exit 1
+        fi
+
+    - name: Save optional setup
+      run:  |-
+        curl --create-dirs -O --output-dir "driver" '${{ env.link_optional }}' -K configs/headers.txt --compressed
+
+    - name: Generate new changelog for beta
+      run: |-
+        python generate_changelog.py ${{ env.version }} > configs/generated_changelog_optional.md
+
+    - name: Create new Beta Release
+      run: |-
+        gh release create ${{ env.beta_tag }} \
+          -t "${{ env.beta_tag }} Beta (TEST)" \
+          -F configs/generated_changelog_optional.md \
+          --prerelease --draft
+          
+        gh release upload ${{ env.beta_tag }} ./driver/*.exe
+
+    - name: Remove driver folder
+      run: rm -rf ./driver    
+
+    - name: Commit report
+      run: |-
+        git config user.name "Automated"
+        git config user.email "actions@users.noreply.github.com"
+        git add -A
+        git commit -m "Latest beta data" || exit 0
+        git push origin main

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -50,6 +50,7 @@ jobs:
         python clean_full.py ${{env.version}} > configs/link_full.txt
         echo "link_full=$(cat configs/link_full.txt)" >> $GITHUB_ENV
     - name: Clear link_full_combined.txt
+      if: env.link != env.old_link && env.tag != env.latest_tag
       run: echo "" > configs/link_full_combined.txt
     - name: Fetch link for full setup combined(Polaris/Vega + RDNA)
       if: env.link != env.old_link && env.tag != env.latest_tag

--- a/clean_optional.py
+++ b/clean_optional.py
@@ -1,0 +1,42 @@
+import requests
+from bs4 import BeautifulSoup
+
+headers = {
+    'User-Agent':
+    'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36',
+    "Upgrade-Insecure-Requests": "1",
+    "DNT": "1",
+    "Accept":
+    "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate"
+}
+
+# AMD driver download page URL
+url = "https://www.amd.com/en/support/downloads/drivers.html/graphics/radeon-rx/radeon-rx-7000-series/amd-radeon-rx-7900-xt.html"
+
+# Make the HTTP request and get the HTML content
+response = requests.get(url, headers=headers)
+html = response.content
+
+# Parse the HTML
+soup = BeautifulSoup(html, 'html.parser')
+
+# Find all <article> elements containing driver information
+articles = soup.find_all("article", class_="container-fluid")
+
+# Loop through articles to find one that contains "Optional"
+download_link = None
+for article in articles:
+    if article.find("p", string=lambda text: text and "Optional" in text):
+        # Find the first <a> link within the same article
+        link_tag = article.find("a", href=True)
+        if link_tag:
+            download_link = link_tag["href"]
+            break  # Stop after finding the first valid link
+
+# Print the result
+if download_link:
+    print(download_link)
+else:
+    print("Download link not found")

--- a/configs/link_optional.txt
+++ b/configs/link_optional.txt
@@ -1,0 +1,1 @@
+https://drivers.amd.com/drivers/amd-software-adrenalin-edition-25.1.1-win10-win11-jan2025-rdna.exe


### PR DESCRIPTION
This PR introduces an "beta release workflow" that detects new AMD optional drivers, downloads the corresponding setup files, and creates a pre-release on GitHub if a new version is found.

Why Beta Releases?
AMD occasionally releases updates that are not WHQL Recommended, meaning they are still in a testing phase. These versions will be published as pre-releases on GitHub, allowing users to try them out before an official stable release.

Only when a version is officially marked as WHQL Recommended, the latest stable release will be updated accordingly. This ensures that the main release remains aligned with WHQL-certified versions while still providing access to beta versions for testing.